### PR TITLE
feat!: Add support for multiple budget types and flexible notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ Now the Budgets/Cost Explorer values be the same. AWS expects Cloud Explorer par
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.52.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13.0 |
 
 ## Modules
 
@@ -87,13 +87,19 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_limit_amount"></a> [limit\_amount](#input\_limit\_amount) | The amount of cost or usage being measured for a budget | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | Budget name | `string` | n/a | yes |
-| <a name="input_subscriber_email_addresses"></a> [subscriber\_email\_addresses](#input\_subscriber\_email\_addresses) | E-mail addresses to notify when the threshold is met | `list(string)` | n/a | yes |
+| <a name="input_auto_adjust_data"></a> [auto\_adjust\_data](#input\_auto\_adjust\_data) | The parameters that determine the budget amount for an auto-adjusting budget. | <pre>object({<br/>    auto_adjust_type      = string<br/>    last_auto_adjust_time = optional(string)<br/>    historical_options = optional(object({<br/>      budget_adjustment_period   = number<br/>      lookback_available_periods = optional(number)<br/>    }))<br/>  })</pre> | `null` | no |
+| <a name="input_billing_view_arn"></a> [billing\_view\_arn](#input\_billing\_view\_arn) | The Amazon Resource Name (ARN) that uniquely identifies a specific billing view to use for the budget. | `string` | `null` | no |
+| <a name="input_budget_type"></a> [budget\_type](#input\_budget\_type) | Whether this budget tracks monetary cost or usage. | `string` | `"COST"` | no |
 | <a name="input_cost_filter"></a> [cost\_filter](#input\_cost\_filter) | Cost filters to apply to the budget | `map(any)` | `{}` | no |
-| <a name="input_cost_types"></a> [cost\_types](#input\_cost\_types) | Cost types to apply to the budget | <pre>object({<br>    include_credit             = optional(bool, false)<br>    include_discount           = optional(bool, false)<br>    include_other_subscription = optional(bool, false)<br>    include_recurring          = optional(bool, false)<br>    include_refund             = optional(bool, false)<br>    include_subscription       = optional(bool, false)<br>    include_support            = optional(bool, false)<br>    include_tax                = optional(bool, false)<br>    include_upfront            = optional(bool, false)<br>    use_amortized              = optional(bool, true)<br>  })</pre> | <pre>{<br>  "include_credit": false,<br>  "include_discount": false,<br>  "include_other_subscription": false,<br>  "include_recurring": false,<br>  "include_refund": false,<br>  "include_subscription": false,<br>  "include_support": false,<br>  "include_tax": false,<br>  "include_upfront": false,<br>  "use_amortized": true<br>}</pre> | no |
+| <a name="input_cost_types"></a> [cost\_types](#input\_cost\_types) | Cost types to apply to the budget | <pre>object({<br/>    include_credit             = optional(bool, false)<br/>    include_discount           = optional(bool, false)<br/>    include_other_subscription = optional(bool, false)<br/>    include_recurring          = optional(bool, false)<br/>    include_refund             = optional(bool, false)<br/>    include_subscription       = optional(bool, false)<br/>    include_support            = optional(bool, false)<br/>    include_tax                = optional(bool, false)<br/>    include_upfront            = optional(bool, false)<br/>    use_amortized              = optional(bool, true)<br/>    use_blended                = optional(bool, false)<br/>  })</pre> | `{}` | no |
+| <a name="input_limit_amount"></a> [limit\_amount](#input\_limit\_amount) | The amount of cost or usage being measured for a budget | `string` | `null` | no |
 | <a name="input_limit_unit"></a> [limit\_unit](#input\_limit\_unit) | The unit of measurement used for the budget forecast, actual spend, or budget threshold | `string` | `"USD"` | no |
-| <a name="input_notification_threshold"></a> [notification\_threshold](#input\_notification\_threshold) | % threshold when the notification should be sent | `number` | `100` | no |
+| <a name="input_name"></a> [name](#input\_name) | Budget name. Either name or name\_prefix must be provided, but not both | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Budget name prefix. Either name or name\_prefix must be provided, but not both | `string` | `null` | no |
+| <a name="input_notifications"></a> [notifications](#input\_notifications) | List of notifications for the budget. Each notification defines threshold, type, and subscribers. | <pre>list(object({<br/>    comparison_operator        = optional(string, "GREATER_THAN")<br/>    notification_type          = optional(string, "FORECASTED")<br/>    subscriber_email_addresses = optional(list(string), [])<br/>    subscriber_sns_topic_arns  = optional(list(string), [])<br/>    threshold                  = optional(number, 100)<br/>    threshold_type             = optional(string, "PERCENTAGE")<br/>  }))</pre> | `[]` | no |
+| <a name="input_planned_limit"></a> [planned\_limit](#input\_planned\_limit) | A list of planned budget limits. Each limit defines a budget amount, start time, and optional unit. | <pre>list(object({<br/>    amount     = number<br/>    start_time = string<br/>    unit       = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_time_period_end"></a> [time\_period\_end](#input\_time\_period\_end) | The end of the time period covered by the budget. There are no restrictions on the end date. `Format: 2017-01-01_12:00`. | `string` | `null` | no |
+| <a name="input_time_period_start"></a> [time\_period\_start](#input\_time\_period\_start) | The start of the time period covered by the budget. If not provided, defaults to the current date. `Format: 2017-01-01_12:00`. | `string` | `null` | no |
 | <a name="input_time_unit"></a> [time\_unit](#input\_time\_unit) | The length of time until a budget resets the actual and forecasted spend | `string` | `"MONTHLY"` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -2,6 +2,46 @@
 
 Terraform module to create and manage an AWS Budget.
 
+## Budget Types
+
+This module supports three mutually exclusive budget configuration options. You must specify exactly one:
+
+### 1️⃣ Enforcement Budget – `var.limit_amount`
+
+"Do not exceed this"
+
+Use this for simple, fixed-amount budgets that set a hard spending threshold. This is the most common and straightforward budget type.
+
+- Single fixed amount for the entire time period
+- Simple to configure and understand
+- Best for cost control and alerts
+
+**Example use case:** A workload with a fixed monthly cloud budget of $50,000.
+
+### 2️⃣ Planned Budget – `var.planned_limit`
+
+"What we intend to spend"
+
+Use this for budgets with predetermined spending limits that vary over time. Perfect for projects with phased spending plans or seasonal workload patterns.
+
+- Allows you to define multiple budget periods with different amounts
+- Each period has a specific start time and amount
+- Ideal for forecasting and planning scenarios
+
+**Example use case:** A project that expects $10,000 spend in Q1, $15,000 in Q2, and $20,000 in Q3-Q4.
+
+### 3️⃣ Auto-Adjusting Budget – `var.auto_adjust_data`
+
+"What AWS expects we'll spend"
+
+Use this for budgets that automatically adjust based on your historical or forecasted spending patterns. AWS analyzes your spending trends and sets the budget accordingly.
+
+- Dynamically adjusts based on historical spend or AWS forecasts
+- Useful for stable, predictable workloads
+- Reduces manual budget maintenance
+
+**Example use case:** Production environments with steady, predictable usage that grows gradually over time.
+
 > [!IMPORTANT]
 > Please note a limitation in AWS Budgets in comparison to Cost Explorer: AWS Budgets does not currently fully align with Cost Explorer, lacking support for charge types related to Savings Plans or reservation-applied usage. Consequently, the expenditure displayed in AWS Budgets may differ from what you observe in AWS Cost Explorer or your AWS bill.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,46 @@
+# Upgrading Notes
+
+This document captures required refactoring when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v1.0.0
+
+### Key Changes
+
+- **Notifications** (breaking): `notification_threshold` and `subscriber_email_addresses` variables removed and replaced with `notifications` list
+- **Budget configuration** (enhancement): `limit_amount` is now optional and one of three mutually exclusive options: `limit_amount`, `auto_adjust_data`, or `planned_limit`
+- **Naming** (enhancement): `name` variable is now optional and must be used exclusively with `name_prefix` (exactly one required)
+- **Time units** (enhancement): Added `"DAILY"` support to `time_unit` validation
+- **Budget type** (enhancement): Added `budget_type` variable (defaults to `"COST"` for backward compatibility)
+- **Time periods** (enhancement): Added `time_period_start` and `time_period_end` variables for custom time ranges
+- **Billing views** (enhancement): Added `billing_view_arn` variable for billing view integration
+- **Cost types** (enhancement): Added `use_blended` field to `cost_types` object
+
+#### Variables
+
+The `notification_threshold` and `subscriber_email_addresses` variables have been replaced with a flexible `notifications` list.
+
+**Before:**
+
+```hcl
+module "budget" {
+  source = "..."
+
+  notification_threshold     = 100
+  subscriber_email_addresses = ["example@example.com"]
+}
+```
+
+**After:**
+
+```hcl
+module "budget" {
+  source = "..."
+
+  notifications = [
+    {
+      threshold                  = 100
+      subscriber_email_addresses = ["example@example.com"]
+    }
+  ]
+}
+```

--- a/examples/auto-adjusting/main.tf
+++ b/examples/auto-adjusting/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "auto_adjusting_budget" {
+  source = "../.."
+
+  name_prefix = "auto-adjusting"
+
+  auto_adjust_data = {
+    auto_adjust_type = "FORECAST"
+  }
+
+  notifications = [
+    {
+      subscriber_email_addresses = ["example@example.com"]
+    }
+  ]
+}

--- a/examples/auto-adjusting/terraform.tf
+++ b/examples/auto-adjusting/terraform.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = ">= 6.13.0"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.9.0"
 }

--- a/examples/enforcement/main.tf
+++ b/examples/enforcement/main.tf
@@ -19,8 +19,13 @@ module "budgets" {
   for_each = local.aws_budgets
   source   = "../.."
 
-  name                       = each.key
-  cost_filter                = each.value.cost_filter
-  limit_amount               = each.value.limit_amount
-  subscriber_email_addresses = ["example@example.com"]
+  name         = each.key
+  cost_filter  = each.value.cost_filter
+  limit_amount = each.value.limit_amount
+
+  notifications = [
+    {
+      subscriber_email_addresses = ["example@example.com"]
+    }
+  ]
 }

--- a/examples/enforcement/terraform.tf
+++ b/examples/enforcement/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.13.0"
+    }
+  }
+  required_version = ">= 1.9.0"
+}

--- a/examples/planned/main.tf
+++ b/examples/planned/main.tf
@@ -1,0 +1,33 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "planned_budget" {
+  source = "../.."
+
+  name_prefix = "planned"
+
+  planned_limit = [
+    {
+      amount     = 10000
+      start_time = "2026-01-01_00:00"
+      unit       = "USD"
+    },
+    {
+      amount     = 15000
+      start_time = "2026-04-01_00:00"
+      unit       = "USD"
+    },
+    {
+      amount     = 20000
+      start_time = "2026-07-01_00:00"
+      unit       = "USD"
+    }
+  ]
+
+  notifications = [
+    {
+      subscriber_email_addresses = ["example@example.com"]
+    }
+  ]
+}

--- a/examples/planned/terraform.tf
+++ b/examples/planned/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.13.0"
+    }
+  }
+  required_version = ">= 1.9.0"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,31 @@
 resource "aws_budgets_budget" "default" {
-  name              = "budget-${var.name}-${lower(var.time_unit)}"
-  budget_type       = "COST"
+  name              = var.name != null ? "budget-${var.name}-${lower(var.time_unit)}" : null
+  name_prefix       = var.name_prefix
+  billing_view_arn  = var.billing_view_arn
+  budget_type       = var.budget_type
   limit_amount      = var.limit_amount
   limit_unit        = var.limit_unit
-  time_period_start = "${substr(timestamp(), 0, 10)}_00:00"
+  time_period_end   = var.time_period_end
+  time_period_start = var.time_period_start != null ? var.time_period_start : "${substr(timestamp(), 0, 10)}_00:00"
   time_unit         = var.time_unit
+
+  dynamic "auto_adjust_data" {
+    for_each = var.auto_adjust_data != null ? [var.auto_adjust_data] : []
+
+    content {
+      auto_adjust_type      = auto_adjust_data.value.auto_adjust_type
+      last_auto_adjust_time = auto_adjust_data.value.last_auto_adjust_time
+
+      dynamic "historical_options" {
+        for_each = auto_adjust_data.value.historical_options != null ? [auto_adjust_data.value.historical_options] : []
+
+        content {
+          budget_adjustment_period   = historical_options.value.budget_adjustment_period
+          lookback_available_periods = historical_options.value.lookback_available_periods
+        }
+      }
+    }
+  }
 
   dynamic "cost_filter" {
     for_each = var.cost_filter
@@ -26,14 +47,30 @@ resource "aws_budgets_budget" "default" {
     include_tax                = var.cost_types.include_tax
     include_upfront            = var.cost_types.include_upfront
     use_amortized              = var.cost_types.use_amortized
+    use_blended                = var.cost_types.use_blended
   }
 
-  notification {
-    comparison_operator        = "GREATER_THAN"
-    threshold                  = var.notification_threshold
-    threshold_type             = "PERCENTAGE"
-    notification_type          = "FORECASTED"
-    subscriber_email_addresses = var.subscriber_email_addresses
+  dynamic "notification" {
+    for_each = var.notifications
+
+    content {
+      comparison_operator        = notification.value.comparison_operator
+      notification_type          = notification.value.notification_type
+      subscriber_email_addresses = notification.value.subscriber_email_addresses
+      subscriber_sns_topic_arns  = notification.value.subscriber_sns_topic_arns
+      threshold                  = notification.value.threshold
+      threshold_type             = notification.value.threshold_type
+    }
+  }
+
+  dynamic "planned_limit" {
+    for_each = var.planned_limit
+
+    content {
+      amount     = planned_limit.value.amount
+      start_time = planned_limit.value.start_time
+      unit       = planned_limit.value.unit
+    }
   }
 
   lifecycle {

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = ">= 6.13.0"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.9.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,46 @@
+variable "auto_adjust_data" {
+  type = object({
+    auto_adjust_type      = string
+    last_auto_adjust_time = optional(string)
+    historical_options = optional(object({
+      budget_adjustment_period   = number
+      lookback_available_periods = optional(number)
+    }))
+  })
+  default     = null
+  description = "The parameters that determine the budget amount for an auto-adjusting budget."
+
+  validation {
+    condition     = var.auto_adjust_data == null || contains(["HISTORICAL", "FORECAST"], var.auto_adjust_data.auto_adjust_type)
+    error_message = "auto_adjust_type must be either \"HISTORICAL\" or \"FORECAST\"."
+  }
+
+  validation {
+    condition = var.auto_adjust_data == null || var.auto_adjust_data.historical_options == null || (
+      var.auto_adjust_data.historical_options.budget_adjustment_period >= 1 &&
+      var.auto_adjust_data.historical_options.budget_adjustment_period <= 60
+    )
+    error_message = "if provided, budget_adjustment_period must be between 1 and 60."
+  }
+}
+
+variable "billing_view_arn" {
+  type        = string
+  default     = null
+  description = "The Amazon Resource Name (ARN) that uniquely identifies a specific billing view to use for the budget."
+}
+
+variable "budget_type" {
+  type        = string
+  default     = "COST"
+  description = "Whether this budget tracks monetary cost or usage."
+
+  validation {
+    condition     = contains(["COST", "USAGE", "SAVINGS_PLANS_UTILIZATION", "RI_UTILIZATION"], var.budget_type)
+    error_message = "Allowed values are \"COST\", \"USAGE\", \"SAVINGS_PLANS_UTILIZATION\" or \"RI_UTILIZATION\"."
+  }
+}
+
 variable "cost_filter" {
   type        = map(any)
   default     = {}
@@ -16,25 +59,25 @@ variable "cost_types" {
     include_tax                = optional(bool, false)
     include_upfront            = optional(bool, false)
     use_amortized              = optional(bool, true)
+    use_blended                = optional(bool, false)
   })
-  default = {
-    include_credit             = false
-    include_discount           = false
-    include_other_subscription = false
-    include_recurring          = false
-    include_refund             = false
-    include_subscription       = false
-    include_support            = false
-    include_tax                = false
-    include_upfront            = false
-    use_amortized              = true
-  }
+  default     = {}
   description = "Cost types to apply to the budget"
 }
 
 variable "limit_amount" {
   type        = string
+  default     = null
   description = "The amount of cost or usage being measured for a budget"
+
+  validation {
+    condition = (
+      (var.limit_amount != null && var.auto_adjust_data == null && length(var.planned_limit) == 0) ||
+      (var.limit_amount == null && var.auto_adjust_data != null && length(var.planned_limit) == 0) ||
+      (var.limit_amount == null && var.auto_adjust_data == null && length(var.planned_limit) > 0)
+    )
+    error_message = "Exactly one of 'limit_amount', 'auto_adjust_data', or 'planned_limit' must be provided."
+  }
 }
 
 variable "limit_unit" {
@@ -45,18 +88,82 @@ variable "limit_unit" {
 
 variable "name" {
   type        = string
-  description = "Budget name"
+  default     = null
+  description = "Budget name. Either name or name_prefix must be provided, but not both"
+
+  validation {
+    condition     = (var.name != null && var.name_prefix == null) || (var.name == null && var.name_prefix != null)
+    error_message = "Exactly one of 'name' or 'name_prefix' must be provided."
+  }
 }
 
-variable "notification_threshold" {
-  type        = number
-  default     = 100
-  description = "% threshold when the notification should be sent"
+variable "name_prefix" {
+  type        = string
+  default     = null
+  description = "Budget name prefix. Either name or name_prefix must be provided, but not both"
 }
 
-variable "subscriber_email_addresses" {
-  type        = list(string)
-  description = "E-mail addresses to notify when the threshold is met"
+variable "notifications" {
+  type = list(object({
+    comparison_operator        = optional(string, "GREATER_THAN")
+    notification_type          = optional(string, "FORECASTED")
+    subscriber_email_addresses = optional(list(string), [])
+    subscriber_sns_topic_arns  = optional(list(string), [])
+    threshold                  = optional(number, 100)
+    threshold_type             = optional(string, "PERCENTAGE")
+  }))
+  default     = []
+  description = "List of notifications for the budget. Each notification defines threshold, type, and subscribers."
+
+  validation {
+    condition = alltrue([
+      for n in var.notifications : contains(["GREATER_THAN", "LESS_THAN", "EQUAL_TO"], n.comparison_operator)
+    ])
+    error_message = "comparison_operator must be one of: GREATER_THAN, LESS_THAN, EQUAL_TO."
+  }
+
+  validation {
+    condition = alltrue([
+      for n in var.notifications : contains(["PERCENTAGE", "ABSOLUTE_VALUE"], n.threshold_type)
+    ])
+    error_message = "threshold_type must be either PERCENTAGE or ABSOLUTE_VALUE."
+  }
+
+  validation {
+    condition = alltrue([
+      for n in var.notifications : contains(["ACTUAL", "FORECASTED"], n.notification_type)
+    ])
+    error_message = "notification_type must be either ACTUAL or FORECASTED."
+  }
+
+  validation {
+    condition = alltrue([
+      for n in var.notifications : length(n.subscriber_email_addresses) > 0 || length(n.subscriber_sns_topic_arns) > 0
+    ])
+    error_message = "Each notification must have at least one subscriber (email or SNS topic)."
+  }
+}
+
+variable "planned_limit" {
+  type = list(object({
+    amount     = number
+    start_time = string
+    unit       = string
+  }))
+  default     = []
+  description = "A list of planned budget limits. Each limit defines a budget amount, start time, and optional unit."
+}
+
+variable "time_period_end" {
+  type        = string
+  default     = null
+  description = "The end of the time period covered by the budget. There are no restrictions on the end date. `Format: 2017-01-01_12:00`."
+}
+
+variable "time_period_start" {
+  type        = string
+  default     = null
+  description = "The start of the time period covered by the budget. If not provided, defaults to the current date. `Format: 2017-01-01_12:00`."
 }
 
 variable "time_unit" {
@@ -65,7 +172,7 @@ variable "time_unit" {
   description = "The length of time until a budget resets the actual and forecasted spend"
 
   validation {
-    condition     = contains(["MONTHLY", "QUARTERLY", "ANNUALLY"], var.time_unit)
-    error_message = "Allowed values are \"MONTHLY\", \"QUARTERLY\" or \"ANNUALLY\"."
+    condition     = contains(["DAILY", "MONTHLY", "QUARTERLY", "ANNUALLY"], var.time_unit)
+    error_message = "Allowed values are \"DAILY\", \"MONTHLY\", \"QUARTERLY\" or \"ANNUALLY\"."
   }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This PR adds support for all three AWS Budget types (enforcement, planned, and auto-adjusting budgets) and refactors the notification system to support multiple notifications with different configurations. The module now supports daily budgets, billing views, custom time periods, and flexible naming options. 

## :rocket: Motivation

The previous module only supported simple enforcement budgets with a single notification configuration. AWS Budgets supports three distinct budget types, each suited for different use cases. This enhancement enables users to leverage all budget types and configure multiple notifications with different thresholds and types, providing more flexibility for cost management strategies.

## :pencil: Additional Information

- See UPGRADING.md for complete migration instructions
- Updated README with detailed budget type explanations and use cases
