### PR TITLE
fix: validation conditions on auto_adjust_data variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -11,15 +11,15 @@ variable "auto_adjust_data" {
   description = "The parameters that determine the budget amount for an auto-adjusting budget."
 
   validation {
-    condition     = var.auto_adjust_data == null || contains(["HISTORICAL", "FORECAST"], var.auto_adjust_data.auto_adjust_type)
+    condition     = var.auto_adjust_data == null || try(contains(["HISTORICAL", "FORECAST"], var.auto_adjust_data.auto_adjust_type), false)
     error_message = "auto_adjust_type must be either \"HISTORICAL\" or \"FORECAST\"."
   }
 
   validation {
-    condition = var.auto_adjust_data == null || var.auto_adjust_data.historical_options == null || (
+    condition = var.auto_adjust_data == null || try(var.auto_adjust_data.historical_options == null, false) || try((
       var.auto_adjust_data.historical_options.budget_adjustment_period >= 1 &&
       var.auto_adjust_data.historical_options.budget_adjustment_period <= 60
-    )
+    ), false)
     error_message = "if provided, budget_adjustment_period must be between 1 and 60."
   }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This will fix the validation conditions on `var.auto_adjust_data`. Currently, if a module has `var.auto_adjust_data` unset, the validation fails because the default value is `null`, and therefore cannot be evaluated by the condition.

```hcl
Error: Attempt to get attribute from null value
on .terraform/modules/budgets/variables.tf line 14, in variable "auto_adjust_data":

    condition     = var.auto_adjust_data == null || contains(["HISTORICAL", "FORECAST"], var.auto_adjust_data.auto_adjust_type)

var.auto_adjust_data is null
This value is null, so it does not have any attributes.
```


Adding `try()` to the validation conditions would ensure that validation will proceed but will return `false` if the value provided is `null`, instead of failing with an evaluation error.

## :rocket: Motivation

This will allow consuming modules to optionally set `var.auto_adjust_data`.
